### PR TITLE
Add manual web-app deploy workflow for Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,60 @@
+name: Deploy web app to Cloudflare Pages
+
+# Builds the gtacompanion Expo web export and deploys it to the
+# companion-for-gta-online Pages project. Lives in this repo because the
+# Cloudflare secrets (already used for the KV publish) are configured here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_ref:
+        description: "gontii/gtacompanion ref to deploy"
+        required: false
+        default: "claude/app-development-xdlk24"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: false
+
+jobs:
+  deploy-web:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - name: Check out the app repo
+        uses: actions/checkout@v7
+        with:
+          repository: gontii/gtacompanion
+          ref: ${{ inputs.app_ref }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web export
+        run: npm run export:web
+
+      # Deploying to any other branch name would create a preview deployment
+      # instead of updating production, so read the real production branch.
+      - name: Resolve Pages production branch
+        id: pages
+        run: |
+          PROD_BRANCH="$(curl -sf -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/companion-for-gta-online" \
+            | jq -re '.result.production_branch')" || {
+              echo "Could not read the Pages project's production branch — the API token may lack Cloudflare Pages permissions." >&2
+              exit 1
+            }
+          echo "branch=$PROD_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare Pages (production)
+        run: npx wrangler pages deploy --branch "${{ steps.pages.outputs.branch }}" --commit-dirty=true


### PR DESCRIPTION
Follow-up to #1: weekly content went live via KV, but the **web app itself** (the new "New DLC" tab from gontii/gtacompanion#2) needs a Pages redeploy, and the Cloudflare credentials only exist as this repo's Actions secrets.

## What's in here

One new workflow, `deploy-web.yml` (manual `workflow_dispatch` only):

1. Checks out `gontii/gtacompanion` at the `app_ref` input (defaults to `claude/app-development-xdlk24`).
2. `npm ci` + `npm run export:web` (the Expo web bundle — the same build verified locally to contain the DLC tab).
3. Reads the Pages project's `production_branch` from the Cloudflare API — deploying with any other `--branch` would silently create a *preview* deployment instead of updating production.
4. `npx wrangler pages deploy` to production using the existing `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets.

## Known unknowns (the first run will tell)

- If `gtacompanion` is private, the checkout step fails (the default `GITHUB_TOKEN` is repo-scoped) — then the fix is a PAT secret or moving this workflow into the app repo with copied secrets.
- If the API token is KV-only, step 3 fails with a clear message — then the token needs the Cloudflare Pages permission added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9qM15Syybdw8hyxJNKUGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9qM15Syybdw8hyxJNKUGk)_